### PR TITLE
SYNC-336, Clean up sync working directories: database backups

### DIFF
--- a/api/src/main/java/org/openmrs/module/sync/SyncConstants.java
+++ b/api/src/main/java/org/openmrs/module/sync/SyncConstants.java
@@ -160,6 +160,8 @@ public class SyncConstants {
 	
 	public static final String PROPERTY_ALLOW_SELFSIGNED_CERTS = "sync.allow_selfsigned_certs";
 	
+	public static final String PROPERTY_SYNC_CLONED_DATABASE_LOG_ENABLED = "sync.cloned_database.log.enabled";
+	
 	public static final String RESPONSE_SUFFIX = "_response";
 	
 	public static final String DIR_IMPORT = "import";

--- a/omod/src/main/java/org/openmrs/module/sync/web/CreateChildServlet.java
+++ b/omod/src/main/java/org/openmrs/module/sync/web/CreateChildServlet.java
@@ -84,6 +84,13 @@ public class CreateChildServlet extends HttpServlet {
 		IOUtils.copy(new FileInputStream(generatedFile), response.getOutputStream());
 		response.getOutputStream().flush();
 		response.getOutputStream().close();
+		
+		boolean clonedDBLog = Boolean.parseBoolean(Context.getAdministrationService()
+				.getGlobalProperty(SyncConstants.PROPERTY_SYNC_CLONED_DATABASE_LOG_ENABLED, "true"));
+		
+		if (!clonedDBLog){
+			generatedFile.delete();
+		}
 	}
 
 	protected void doPost(HttpServletRequest request,
@@ -118,6 +125,13 @@ public class CreateChildServlet extends HttpServlet {
 				Context.getService(SyncService.class).execGeneratedFile(file);
 
 				reply(response,"Child database successfully updated","green");
+				
+				boolean clonedDBLog = Boolean.parseBoolean(Context.getAdministrationService()
+						.getGlobalProperty(SyncConstants.PROPERTY_SYNC_CLONED_DATABASE_LOG_ENABLED, "true"));
+				
+				if (!clonedDBLog){
+					file.delete();
+				}
 			} catch (Exception ex) {
 				log.warn("Unable to read the clone data file", ex);
 				reply(response,"Unable to read the data clonefile"+ ex.toString(),"red");

--- a/omod/src/main/java/org/openmrs/module/sync/web/controller/ImportListController.java
+++ b/omod/src/main/java/org/openmrs/module/sync/web/controller/ImportListController.java
@@ -217,6 +217,13 @@ public class ImportListController extends SimpleFormController {
 				StringWriter writer = new StringWriter();
 				IOUtils.copy(new FileInputStream(file), writer);
 				this.sendCloneResponse(writer.toString(), response, false);
+				
+				boolean clonedDBLog = Boolean.parseBoolean(Context.getAdministrationService()
+						.getGlobalProperty(SyncConstants.PROPERTY_SYNC_CLONED_DATABASE_LOG_ENABLED, "true"));
+				
+				if (!clonedDBLog){
+					file.delete();
+				}
 			}
 			catch (Exception ex) {
 				log.warn(ex.toString());

--- a/omod/src/main/java/org/openmrs/module/sync/web/dwr/DWRSyncService.java
+++ b/omod/src/main/java/org/openmrs/module/sync/web/dwr/DWRSyncService.java
@@ -72,6 +72,13 @@ public class DWRSyncService {
 					Context.getService(SyncService.class).execGeneratedFile(file);
 					item.setResponsefileName(file.getName());
 					item.setErrorMessage("Parent data cloned successfully");
+					
+					boolean clonedDBLog = Boolean.parseBoolean(Context.getAdministrationService()
+							.getGlobalProperty(SyncConstants.PROPERTY_SYNC_CLONED_DATABASE_LOG_ENABLED, "true"));
+					
+					if (!clonedDBLog){
+						file.delete();
+					}
 				}
 				catch (FileNotFoundException e) {
 					item.setErrorMessage("Unable to save file(" + file.getAbsolutePath() + ")");

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -122,6 +122,11 @@
         <description>Boolean value indicating whether or not create a transmission log in .OpenMRS/sync/recrd folder. Available options: true,false </description>
     </globalProperty>
     <globalProperty>
+        <property>sync.cloned_database.log.enabled</property>
+        <defaultValue>true</defaultValue>
+        <description>Boolean value indicating whether or not create a backup file of the cloned database in .OpenMRS/sync folder. Available options: true,false </description>
+    </globalProperty>
+    <globalProperty>
         <property>sync.allow_selfsigned_certs</property>
         <defaultValue>false</defaultValue>
         <description>Boolean value indicating wheter allow the use of self-signed certificates in https connections. Available options:true,false </description>


### PR DESCRIPTION
Before merging the pull request, I would like to ask about something: the modified methods in the pull request are "DWRSyncService" and "ImportListController", which control execution and generation of backup file respectively. But looking at "org.openmrs.module.sync.web.CreateChildServlet", it seems that this class has a similar purpose. Is it right? Am I missing something?