### PR TITLE
Set fields in objects directly if there is no setter.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,5 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>sync</artifactId>

--- a/api/src/main/java/org/openmrs/module/sync/SyncUtil.java
+++ b/api/src/main/java/org/openmrs/module/sync/SyncUtil.java
@@ -14,6 +14,7 @@
 package org.openmrs.module.sync;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.HibernateException;
@@ -234,6 +235,12 @@ public class SyncUtil {
 		
 		log.debug("getting setter method");
 		Method m = SyncUtil.getSetterMethod(o.getClass(), propName, propVal.getClass());
+		if (m == null) {
+			// We couldn't find a setter method. Let's try setting the field directly instead.
+			log.debug("couldn't find setter method, setting field '" + propName + "' directly.");
+			FieldUtils.writeField(o, propName, propVal, true);
+			return;
+		}
 		
 		boolean acc = m.isAccessible();
 		m.setAccessible(true);

--- a/api/src/test/java/org/openmrs/module/sync/SyncUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/sync/SyncUtilTest.java
@@ -15,9 +15,13 @@ package org.openmrs.module.sync;
 
 import java.lang.reflect.Method;
 
+import org.junit.Assert;
 import org.junit.Test;
-import org.openmrs.module.sync.SyncUtil;
-import org.springframework.util.Assert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 /**
  * Tests various methods of the SyncUtil class.
@@ -27,43 +31,53 @@ public class SyncUtilTest {
 	@Test
 	public void getSetterMethod_shouldReturnMethodForPrimitiveInt(){
 		Method m = SyncUtil.getSetterMethod(new Xform().getClass(), "intField", new Integer(1).getClass());
-		Assert.notNull(m);
+		assertNotNull(m);
 	}
 	
 	@Test
 	public void getSetterMethod_shouldReturnMethodForPrimitiveLong(){
 		Method m = SyncUtil.getSetterMethod(new Xform().getClass(), "longField", new Long(1).getClass());
-		Assert.notNull(m);
+		assertNotNull(m);
 	}
 	
 	@Test
 	public void getSetterMethod_shouldReturnMethodForPrimitiveDouble(){
 		Method m = SyncUtil.getSetterMethod(new Xform().getClass(), "doubleField", new Double(1).getClass());
-		Assert.notNull(m);
+		assertNotNull(m);
 	}
 	
 	@Test
 	public void getSetterMethod_shouldReturnMethodForPrimitiveFloat(){
 		Method m = SyncUtil.getSetterMethod(new Xform().getClass(), "floatField", new Float(1).getClass());
-		Assert.notNull(m);
+		assertNotNull(m);
 	}
 	
 	@Test
 	public void getSetterMethod_shouldReturnMethodForPrimitiveBoolean(){
 		Method m = SyncUtil.getSetterMethod(new Xform().getClass(), "booleanField", new Boolean(true).getClass());
-		Assert.notNull(m);
+		assertNotNull(m);
 	}
 	
 	@Test
 	public void getSetterMethod_shouldReturnMethodForPrimitiveShort(){
 		Method m = SyncUtil.getSetterMethod(new Xform().getClass(), "shortField", new Short((short)1).getClass());
-		Assert.notNull(m);
+		assertNotNull(m);
 	}
 	
 	@Test
 	public void getSetterMethod_shouldReturnMethodForPrimitiveByte(){
 		Method m = SyncUtil.getSetterMethod(new Xform().getClass(), "byteField", new Byte((byte)1).getClass());
-		Assert.notNull(m);
+		assertNotNull(m);
+	}
+
+	@Test
+	public void setProperty_shouldSetFieldDirectlyWithNoSetter() throws Exception {
+		Object someObject = new Object();
+		Xform obj = new Xform();
+		assertNull(obj.getFieldWithNoSetter());
+		SyncUtil.setProperty(obj, "fieldWithNoSetter", someObject);
+		assertSame(someObject, obj.getFieldWithNoSetter());
+
 	}
 	
 	public class Xform {
@@ -75,6 +89,7 @@ public class SyncUtilTest {
 		boolean booleanField;
 		byte byteField;
 		short shortField;
+		private Object fieldWithNoSetter = null;
 
         public int getIntField() {
         	return intField;
@@ -131,5 +146,9 @@ public class SyncUtilTest {
         public void setShortField(short shortField) {
         	this.shortField = shortField;
         }
+
+		public Object getFieldWithNoSetter() {
+			return fieldWithNoSetter;
+		}
 	}
 }


### PR DESCRIPTION
This enables Orders to be synced in OpenMRS 1.10. Orders have an `order_number` field, but don't have a setter for the order number, because order numbers are read-only. Previously, the sync module
would die with a `NullPointerException` when this was the case. Now, we fall back to writing the
field directly if the setter can't be found.

We fall back to directly writing the field instead of making it the default behavior because making
it default behavior causes some tests to fail for a reason I couldn't determine.