### PR TITLE
Sync 349

### DIFF
--- a/api/src/main/java/org/openmrs/module/sync/api/db/hibernate/HibernateSyncInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/sync/api/db/hibernate/HibernateSyncInterceptor.java
@@ -384,7 +384,7 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 	}
 
 	/**
-	 * No operation, logging only
+	 * Records an end of the transaction on the thread local that is tracking the sync records
 	 * @see EmptyInterceptor#afterTransactionCompletion(Transaction)
 	 */
 	@Override

--- a/api/src/main/java/org/openmrs/module/sync/api/db/hibernate/HibernateSyncInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/sync/api/db/hibernate/HibernateSyncInterceptor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.CallbackException;
@@ -88,8 +89,7 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 
 	private static HibernateSyncInterceptor instance;
 	private ApplicationContext context;
-	private static ThreadLocal<SyncRecord> syncRecordHolder = new ThreadLocal<SyncRecord>();
-	private static ThreadLocal<Stack<Boolean>> isTxnProcessRegistered = new ThreadLocal<Stack<Boolean>>();
+	private static final ThreadLocal<SyncRecordHolder> syncRecordThreadLocal = new ThreadLocal<SyncRecordHolder>();
 
 	private HibernateSyncInterceptor() {
 		log.info("Initializing the synchronization interceptor");
@@ -111,15 +111,16 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 	 */
 	@Override
 	public void afterTransactionBegin(Transaction tx) {
-		if (log.isDebugEnabled()) {
-			log.debug("Transaction Started");
+		SyncRecordHolder holder = syncRecordThreadLocal.get();
+		if (holder == null) {
+			holder = new SyncRecordHolder();
+			syncRecordThreadLocal.set(holder);
 		}
-		Stack<Boolean> stack = isTxnProcessRegistered.get();
-		if (stack == null) {
-			stack = new Stack<Boolean>();
-			isTxnProcessRegistered.set(stack);
+		holder.startTransaction(tx);
+		if (log.isTraceEnabled()) {
+			log.trace("Transaction Started");
+			log.trace(holder);
 		}
-		stack.push(false);
 	}
 
 	/**
@@ -299,22 +300,30 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 	 */
 	private void registerBeforeTransactionCompletionProcess() {
 		log.debug("Registering SyncBeforeTransactionCompletionProcess with the current session");
-		if (isProcessRegistered()) {
-			log.debug("Process is already registered, not registering again...");
+		Transaction tx = getSessionFactory().getCurrentSession().getTransaction();;
+		if (syncRecordThreadLocal.get().isProcessRegistered(tx)) {
+			if (log.isTraceEnabled()) {
+				log.trace("Process is already registered for current thread and txn, not registering again...");
+			}
 		}
 		else {
-			log.debug("No process is yet registered, proceeding...");
+			if (log.isTraceEnabled()) {
+				log.trace("Registering new BeforeTransactionCompletionProcess");
+			}
 			EventSource eventSource = (EventSource) getSessionFactory().getCurrentSession();
 			eventSource.getActionQueue().registerProcess(new BeforeTransactionCompletionProcess() {
 
 				public void doBeforeTransactionCompletion(SessionImplementor sessionImpl) {
 					log.trace("doBeforeTransactionCompletion process: checking for SyncRecord to save");
 					try {
-						SyncRecord record = getSyncRecord();
-						syncRecordHolder.remove();
+						SyncRecord record = syncRecordThreadLocal.get().getSyncRecordForCurrentTx();
 
 						// Does this transaction contain any serialized changes?
 						if (record != null && record.hasItems()) {
+
+							if (log.isTraceEnabled()) {
+								log.trace("Adding Sync Record: " + record.getItems());
+							}
 
 							// Grab user if we have one, and use the UUID of the user as creator of this SyncRecord
 							User user = Context.getAuthenticatedUser();
@@ -339,8 +348,10 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 							record.setTimestamp(new Date());
 							record.setRetryCount(0);
 
-							log.info("Saving SyncRecord " + record.getOriginalUuid() + ": " + record.getItems().size()
-									+ " items");
+							if (log.isTraceEnabled()) {
+								log.trace("Saving SyncRecord " + record.getOriginalUuid() + ": " + record.getItems().size()
+										+ " items");
+							}
 
 							// Save SyncRecord
 							getSyncService().createSyncRecord(record, record.getOriginalUuid());
@@ -358,8 +369,7 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 					}
 				}
 			});
-			isTxnProcessRegistered.get().pop();
-			isTxnProcessRegistered.get().push(true);
+			syncRecordThreadLocal.get().setProcessRegistered(tx,true);
 			log.debug("Successfully registered SyncBeforeTransactionCompletionProcess with the current session");
 		}
 	}
@@ -373,9 +383,7 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 		if (log.isDebugEnabled()) {
 			log.debug("Transaction Completed: " + SyncUtil.formatTransactionStatus(tx));
 		}
-		// Because the beforeTransactionCompletion method is not called on rollback, we need to ensure any syncRecords still on the thread are removed after the tx is completed
-		syncRecordHolder.remove();
-		isTxnProcessRegistered.get().pop();
+		syncRecordThreadLocal.get().endTransaction(tx);
 	}
 
 	/**
@@ -1488,24 +1496,11 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 	}
 
 	/**
-	 * @return the existing sync record for the current thread, creating a new sync record for the thread if none yet exists,
+	 * @return the existing sync record for the current thread / transaction,
+	 * creating a new sync record if none yet exists,
 	 */
 	private static SyncRecord getSyncRecord() {
-		SyncRecord syncRecord = syncRecordHolder.get();
-		if (syncRecord == null) {
-			syncRecord = new SyncRecord();
-			syncRecordHolder.set(syncRecord);
-		}
-		return syncRecord;
-	}
-
-	/**
-	 * @return true if a BeforeTransactionCompletionProcess is already registered with this thread
-	 */
-	private static boolean isProcessRegistered() {
-		Stack<Boolean> stack = isTxnProcessRegistered.get();
-		Boolean val = stack.peek();
-		return val != null && val.booleanValue();
+		return syncRecordThreadLocal.get().getSyncRecordForCurrentTx();
 	}
 
 	/**
@@ -1561,6 +1556,73 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 
 		public String getValue() {
 			return value;
+		}
+	}
+
+	class SyncRecordHolder {
+
+		Stack<Transaction> transactions = new Stack<Transaction>();
+		Map<Transaction, Boolean> processRegistered = new HashMap<Transaction, Boolean>();
+		Map<Transaction, SyncRecord> syncRecords = new HashMap<Transaction, SyncRecord>();
+
+		public SyncRecordHolder() {}
+
+		@Override
+		public String toString() {
+			return "SyncRecords: " + syncRecords.values();
+		}
+
+		public boolean isProcessRegistered(Transaction tx) {
+			return BooleanUtils.isTrue(processRegistered.get(tx));
+		}
+
+		public void setProcessRegistered(Transaction tx, boolean val) {
+			processRegistered.put(tx, val);
+		}
+
+		public SyncRecord getSyncRecord(Transaction tx) {
+			return syncRecords.get(tx);
+		}
+
+		public int getNumberOfSyncRecords() {
+			return syncRecords.size();
+		}
+
+		public boolean hasSyncRecord(Transaction tx) {
+			return syncRecords.containsKey(tx);
+		}
+
+		public SyncRecord startTransaction(Transaction tx) {
+			SyncRecord record = syncRecords.get(tx);
+			if (record != null) {
+				throw new IllegalStateException("Transaction already started");
+			}
+			record = new SyncRecord();
+			syncRecords.put(tx, record);
+			transactions.push(tx);
+			return record;
+		}
+
+		public SyncRecord getSyncRecordForCurrentTx() {
+			Transaction currentTx = transactions.peek();
+			if (currentTx == null) {
+				throw new IllegalStateException("Getting sync record did not find a current tx");
+			}
+			SyncRecord record = syncRecords.get(currentTx);
+			if (record == null) {
+				throw new IllegalStateException("Expected to get the current sync record, but none found");
+			}
+			return record;
+		}
+
+		public SyncRecord endTransaction(Transaction tx) {
+			SyncRecord record = syncRecords.remove(tx);
+			Transaction expected = transactions.pop();
+			if (record == null || expected == null || !expected.equals(tx)) {
+				throw new IllegalStateException("Ending transaction did not find the expected transaction on the stack");
+			}
+			syncRecordThreadLocal.get().setProcessRegistered(tx, false);
+			return record;
 		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/sync/api/db/hibernate/HibernateSyncInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/sync/api/db/hibernate/HibernateSyncInterceptor.java
@@ -309,7 +309,7 @@ public class HibernateSyncInterceptor extends EmptyInterceptor implements Applic
 	 */
 	private void registerBeforeTransactionCompletionProcess() {
 		log.debug("Registering SyncBeforeTransactionCompletionProcess with the current session");
-		Transaction tx = getSessionFactory().getCurrentSession().getTransaction();;
+		Transaction tx = getSessionFactory().getCurrentSession().getTransaction();
 		if (syncRecordThreadLocal.get().isProcessRegistered(tx)) {
 			if (log.isTraceEnabled()) {
 				log.trace("Process is already registered for current thread and txn, not registering again...");

--- a/api/src/test/java/org/openmrs/module/sync/SyncBaseTest.java
+++ b/api/src/test/java/org/openmrs/module/sync/SyncBaseTest.java
@@ -337,14 +337,11 @@ public abstract class SyncBaseTest extends BaseModuleContextSensitiveTest {
 	 * @return
 	 */
 	private int compareVersions(String v1, String v2) throws NumberFormatException {
-		System.out.println("v1: " + v1 + ", v2: " + v2);
 		String[] v1Parts = v1.split("\\.", 3);
 		String[] v2Parts = v2.split("\\.", 3);
-		System.out.println("v1 parts:" + v1Parts + ", v2Parts: " + v2Parts);
 
 		int[] v1Ints = new int[v1Parts.length];
 		for(int x=0; x < v1Parts.length; ++x ) {
-			System.out.println("part " + x + ": " + v1Parts[x]);
 			v1Ints[x] = Integer.parseInt(v1Parts[x]);
 		}
 

--- a/api/src/test/resources/org/openmrs/module/sync/include/SyncCreateTest-openmrs-2.3.xml
+++ b/api/src/test/resources/org/openmrs/module/sync/include/SyncCreateTest-openmrs-2.3.xml
@@ -15,7 +15,12 @@
 	<user_role user_id="1" role="System Developer"/> <!-- uuid="35a05ac6-144e-102b-8d9c-e44ed545d86c" -->
 	<user_role user_id="2" role="Provider"/>
 
-    <concept_name_tag uuid="77397336-e90e-102b-968f-001e378eb67e" concept_name_tag_id="1" tag="default" description="name to use when nothing else is available" creator="1" date_created="2007-05-01 00:00:00.0" voided="false"/>
+	<care_setting care_setting_id="1" name="OUTPATIENT" description="OutPatient" care_setting_type="OUTPATIENT" creator="1" date_created="2008-08-19 12:35:30.0" retired="false" uuid="6f0c9a92-6f24-11e3-af88-005056821db0"/>
+	<care_setting care_setting_id="2" name="INPATIENT" description="InPatient" care_setting_type="INPATIENT" creator="1" date_created="2008-08-19 12:35:30.0" retired="false" uuid="c365e560-c3ec-11e3-9c1a-0800200c9a66"/>
+
+	<order_type order_type_id="1" name="Drug order" java_class_name="org.openmrs.DrugOrder" description="Categorises medication orders for the patient" date_created="2008-08-15 13:49:47.0" retired="false" uuid="131168f4-15f5-102d-96e4-000c29c2a5d7" creator="1" />
+
+	<concept_name_tag uuid="77397336-e90e-102b-968f-001e378eb67e" concept_name_tag_id="1" tag="default" description="name to use when nothing else is available" creator="1" date_created="2007-05-01 00:00:00.0" voided="false"/>
 
 	<concept_class retired="false" concept_class_id="1" name="Test" description="Acq. during patient encounter (vitals, labs, etc.)" creator="1" date_created="2004-02-02 00:00:00.0" uuid="27f7230a-144e-102b-8d9c-e44ed545d86c"/>
 	<concept_class retired="false" concept_class_id="2" name="Procedure" description="Describes a clinical procedure" creator="1" date_created="2004-03-02 00:00:00.0" uuid="27f72d33-144e-102b-8d9c-e44ed545d86c"/>
@@ -104,6 +109,8 @@
 	<concept_set concept_set_id="1" concept_id="13" concept_set="15" sort_weight="0.0" creator="1" date_created="2008-08-18 12:38:58.0" uuid="1a222827-639f-4cb4-961f-1e025bf88d90"/>
 
     <concept_synonym/>
+
+	<drug drug_id="1" concept_id="9" name="Advil" combination="false" strength="200.0mg" creator="1" date_created="2008-01-14 18:09:57.0" retired="false" uuid="29dde6a3-144e-102b-8d9c-e44ed545d86c"/>
 
 	<person_attribute_type retired="false" person_attribute_type_id="1" name="Race" description="Group of persons related by common descent or heredity" format="java.lang.String" searchable="0" creator="1" date_created="2007-05-04 09:59:23.0" uuid="322aa53b-144e-102b-8d9c-e44ed545d86c" sort_weight="1"/>
 	<person_attribute_type retired="false" person_attribute_type_id="2" name="Birthplace" description="Location of persons birth" format="java.lang.String" searchable="0" creator="1" date_created="2007-05-04 09:59:23.0" uuid="322aa923-144e-102b-8d9c-e44ed545d86c" sort_weight="7"/>
@@ -273,6 +280,7 @@
 	<form_field form_field_id="1023" form_id="1" field_id="23" field_part="" parent_form_field="1021" max_occurs="-1" required="false" changed_by="1" date_changed="2006-07-26 05:39:24.0" creator="1" date_created="2006-07-26 05:34:25.0" uuid="a6464f4c-fb9e-102a-b4cd-d5399a5cfee6"/>
 
 	<global_property property="sync.server_name" property_value="parent" uuid="cccc4f4c-fb9e-102a-b4cd-d5399a5cbbbb" />
+	<global_property property="order.nextOrderNumberSeed" property_value="1" uuid="7ed7aeb4-0663-11e1-8c99-2b4f0c4f671b" />
 
 	<visit_type retired="false" visit_type_id="1" name="Unknown" description="Unknown" creator="1" date_created="2005-02-24 00:00:00.0" uuid="2a5cd7ea-144e-102b-8d9c-554ed545d86d"/>
 


### PR DESCRIPTION
Adds a unit test that initially fails in order to test syncing of and encounter with drug orders

* Initial problem:  independent sync records getting created for encounter and drugorder, rather than one sync record with both.
* Fix: update the hibernate interceptor to properly track sync records by transaction, rather than simply by thread 

* Follow-up problem:  once the above fix put all items on the same sync record, the order of items was causing failures as the order set on encounter (which references orders by uuid) was getting saved prior to the order getting saved, so no order was found.
* Fix:  update ingest service to handle items that are collection properties after the other items in the record.

All unit tests passing.
