### PR TITLE
SYNC-364: add REST point to download the parent db

### DIFF
--- a/omod/src/main/java/org/openmrs/sync/rest/CreateChildServerRestController.java
+++ b/omod/src/main/java/org/openmrs/sync/rest/CreateChildServerRestController.java
@@ -1,0 +1,33 @@
+package org.openmrs.sync.rest;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.sync.api.SyncService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@RestController
+public class CreateChildServerRestController {
+    protected Log log = LogFactory.getLog(getClass());
+
+    @GetMapping(value = "/rest/v1/sync/downloadDb", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public @ResponseBody byte[] getDbBackup() throws IOException {
+        try {
+            File outputFile = Context.getService(SyncService.class).generateDataFile();
+            InputStream in = new FileInputStream(outputFile);
+            return IOUtils.toByteArray(in);
+        } catch (Exception e) {
+            log.warn("Error while generating backup file", e);
+            return e.toString().getBytes();
+        }
+    }
+}


### PR DESCRIPTION
@mseaton , I was able to download the parent db using the new REST point below using the following wget command:

db/malawi  > wget --no-check-certificate \
  --method GET \
  --header 'Authorization: Basic Y2lvYW46Q2lvYW4xMjM=' \
   'https://neno-ci.pih-emr.org/openmrs/ws/rest/v1/sync/downloadDb' -O nenoDb.sql
--2025-03-25 08:50:13--  https://neno-ci.pih-emr.org/openmrs/ws/rest/v1/sync/downloadDb
Resolving neno-ci.pih-emr.org (neno-ci.pih-emr.org)... 74.50.48.97
Connecting to neno-ci.pih-emr.org (neno-ci.pih-emr.org)|74.50.48.97|:443... connected.
HTTP request sent, awaiting response... 200 200
Length: 2041352360 (1.9G) [application/octet-stream]
Saving to: ‘nenoDb.sql’

nenoDb.sql                                        100%[============================================================================================================>]   1.90G  6.58MB/s    in 5m 52s  

2025-03-25 08:57:29 (5.53 MB/s) - ‘nenoDb.sql’ saved [2041352360/2041352360]
